### PR TITLE
Documentation improvements based on first partner experiences

### DIFF
--- a/example/playbook.yaml
+++ b/example/playbook.yaml
@@ -25,7 +25,10 @@
     # This is a public key, not a secret, so it's ok to store here.
     git_host_key: bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
 
-    # Your country-specific dlentries and maproom repositories
+    # Your country-specific dlentries and maproom repositories. These
+    # are git repositories that describe the content of your data
+    # library. They are typically created in collaboration with IRI
+    # staff.
     dlentries_repo: git@{{git_host}}:iridl/dlentries_testcountry.git
     maproom_repo: git@{{git_host}}:iridl/maproom_testcountry.git
 

--- a/example/playbook.yaml
+++ b/example/playbook.yaml
@@ -1,16 +1,5 @@
 - hosts: dlservers
   vars:
-    # Optional SMTP server in postfix config file format. If
-    # undefined, mail will be delivered locally.
-    # mail_relay: "[mail.example.com]:25"
-
-    # Email recipients to which automated messages about system status
-    # will be sent. If mail_relay is defined (see above) then these
-    # can be email addresses of the form user@example.com, otherwise
-    # they should be unix user names.
-    admin_emails:
-      - johndoe
-
     # The server that hosts your dlentries and maproom repositories
     git_host: bitbucket.org
 

--- a/example/playbook.yaml
+++ b/example/playbook.yaml
@@ -25,5 +25,6 @@
       # username: uid
       testuser: 1001
 
+  # Invokes the iridl ansible role. Don't modify this.
   roles:
     - iridl.iridl.iridl

--- a/example/playbook.yaml
+++ b/example/playbook.yaml
@@ -1,9 +1,5 @@
 - hosts: dlservers
   vars:
-    # Email address that users of your Data Library should write
-    # to for help
-    support_email: help@example.com
-
     # Optional SMTP server in postfix config file format. If
     # undefined, mail will be delivered locally.
     # mail_relay: "[mail.example.com]:25"

--- a/roles/iridl/defaults/main.yaml
+++ b/roles/iridl/defaults/main.yaml
@@ -46,6 +46,19 @@ dataset_parent_dir: "{{data_mountpoint}}/datalib"
 # volume with multiple TB of space, and ideally not the root volume.
 docker_dir: "{{data_mountpoint}}/docker"
 
+# Email recipients to which cron job output and other automated system
+# status messages will be sent. If mail_relay (see below) is non-empty
+# then these can be email addresses of the form user@example.com,
+# otherwise they should be local unix user names. If left at the
+# default (empty list), messages will be sent to root.
+admin_emails: []
+
+# Optional SMTP server in postfix config file format. If set to null,
+# mail will be delivered locally.
+# mail_relay: "[mail.example.com]:25"
+mail_relay: null
+
+
 # Container version numbers for the various Data Library software
 # packages. Do not use "latest", or you might find your software
 # being updated when you don't expect it, potentially to a

--- a/roles/iridl/templates/postfix/aliases
+++ b/roles/iridl/templates/postfix/aliases
@@ -93,4 +93,7 @@ support:	postmaster
 decode:		root
 
 datag:          root
+
+{% if admin_emails | length > 0 %}
 root:		"{{ admin_emails | join(', ') }}"
+{% endif %}

--- a/roles/iridl/templates/postfix/main.cf
+++ b/roles/iridl/templates/postfix/main.cf
@@ -9,7 +9,7 @@ inet_interfaces = localhost
 inet_protocols = all
 mydestination = $myhostname, localhost.$mydomain, localhost
 unknown_local_recipient_reject_code = 550
-{% if mail_relay is defined %}
+{% if mail_relay is not none %}
 relayhost = {{ mail_relay }}
 {% endif %}
 alias_maps = hash:/etc/aliases


### PR DESCRIPTION
Some improved comments and one substantive change: remove all the email-related configuration from the example config file. The options are still there for future use, but AFAICT we have yet to install anything that sends email or displays the help email address, so there's no point wasting the admin's time configuring them.

@jturmelle do you know of anything that runs at partner sites that sends email? I checked the datag-messages Google Group and couldn't find anything from the Senegal, India, Madagascar, or Niger sites, which are configured to send admin emails to us. (Nothing urgent here, this can wait 'til you get back.)