### PR TITLE
Fix incorrect redirects

### DIFF
--- a/roles/iridl/tasks/main.yaml
+++ b/roles/iridl/tasks/main.yaml
@@ -227,7 +227,7 @@
     dest: "{{squid_config_dir}}/squid.conf"
   vars:
     dl_hostport_regex: "{{ dl_hostport | replace('.', '\\.') }}"
-  notify: reconfigure squid
+  notify: restart squid
 
 
 #

--- a/roles/iridl/tasks/main.yaml
+++ b/roles/iridl/tasks/main.yaml
@@ -225,8 +225,6 @@
   template:
     src: squid.conf
     dest: "{{squid_config_dir}}/squid.conf"
-  vars:
-    dl_hostport_regex: "{{ dl_hostport | replace('.', '\\.') }}"
   notify: restart squid
 
 

--- a/roles/iridl/templates/ingrid-localdefs.tex
+++ b/roles/iridl/templates/ingrid-localdefs.tex
@@ -1,19 +1,11 @@
 \documentclass{article}
 
 \begin{document}
-redirectport is the optional specification of the port to redirect to.
-The default value is the port the server is running on.
-
-In this case, if the port is less than 80, I redirect to 80, otherwise
-I use it (so my experimental version can run on high ports and
-redirect to themselves, the production version redirects to the cache).
 \begin{ingrid}
-%/bindhost (localhost) def
 /redirectport {
-WWWinfo /port known
-{WWWinfo .port dup 85 lt { pop 80} if}
-{80} ifelse
-} def
+  WWWinfo .Host (:) search
+  { pop pop cvi } { pop 80 } ifelse
+}
 /donttrust true  def
 \end{ingrid}
 standardTrailer is the bottom of most of the html pages.  It should

--- a/roles/iridl/templates/squid.conf
+++ b/roles/iridl/templates/squid.conf
@@ -34,7 +34,7 @@ http_access allow ingrid_url
 http_access deny all
 http_reply_access allow all
 
-http_port 80 accel
+http_port 80 vhost
 http_port 3128
 
 cache_peer ingrid parent 80 3130 no-query no-digest originserver monitorinterval=30 monitorurl=/statusmsg monitortimeout=10 monitorsize=3-3 name=ingrid sourcehash weight=24 login=PASS

--- a/roles/iridl/templates/squid.conf
+++ b/roles/iridl/templates/squid.conf
@@ -19,18 +19,20 @@ acl Safe_ports port 777		# multiling http
 acl Safe_ports port 888		# ganglia
 acl CONNECT method CONNECT
 
-acl ingrid_url url_regex ^http://{{dl_hostport_regex}}/
-acl maproom_url url_regex ^http://{{dl_hostport_regex}}/(maproom|uicore|pure|jsonld|localconfig|docfind|dochelp|index.html|\?|$)
+acl inbound myport 80
+
+acl ingrid_url urlpath_regex ^/
+acl maproom_url urlpath_regex ^/(maproom|uicore|pure|jsonld|localconfig|docfind|dochelp|index.html|\?|$)
 {% if python_maproom_repo is defined %}
-acl python_maproom_url url_regex ^http://{{dl_hostport_regex}}/python_maproom
+acl python_maproom_url urlpath_regex ^/python_maproom
 {% endif %}
-acl fbfmaproom_url url_regex ^http://{{dl_hostport_regex}}/fbfmaproom
+acl fbfmaproom_url urlpath_regex ^/fbfmaproom
 
 http_access deny !Safe_ports
 http_access deny CONNECT !SSL_ports
 http_access allow localhost
 http_access allow localnet
-http_access allow ingrid_url
+http_access allow inbound ingrid_url
 http_access deny all
 http_reply_access allow all
 
@@ -44,20 +46,20 @@ cache_peer pymaproom parent 8000 0 no-query no-digest originserver http11 name=p
 {% endif %}
 cache_peer fbfmaproom parent 8000 0 no-query no-digest originserver http11 name=fbfmaproom
 
-cache_peer_access maproom allow maproom_url
+cache_peer_access maproom allow inbound maproom_url
 cache_peer_access maproom deny all
 {% if python_maproom_repo is defined %}
-cache_peer_access pymaproom allow python_maproom_url
+cache_peer_access pymaproom allow inbound python_maproom_url
 cache_peer_access pymaproom deny all
 {% endif %}
-cache_peer_access fbfmaproom allow fbfmaproom_url
+cache_peer_access fbfmaproom allow inbound fbfmaproom_url
 cache_peer_access fbfmaproom deny all
 cache_peer_access ingrid deny maproom_url
 {% if python_maproom_repo is defined %}
 cache_peer_access ingrid deny python_maproom_url
 {% endif %}
 cache_peer_access ingrid deny fbfmaproom_url
-cache_peer_access ingrid allow ingrid_url
+cache_peer_access ingrid allow inbound ingrid_url
 cache_peer_access ingrid deny all
 
 


### PR DESCRIPTION
For as long as I've been here, I've been annoyed by Ingrid using the wrong host and/or port for redirects whenever it's running anywhere other than iridl.ldeo.columbia.edu. It affects partner installs as well as testing on a laptop or dev server. For example, http://41.77.11.10:8091/SOURCES (Malawi) redirects to http://41.77.11.10/SOURCES/, which doesn't work because it's missing the port. More recently, python maprooms are affected too, e.g. http://213.55.84.78:8082/python_maproom redirects to http://dlserver1/python_maproom/ , where both the hostname and the port are wrong.

The solution is in two parts: first, change the squid configuration such that it passes on the original Host header, and second, change the Ingrid configuration such that it uses the original host and port from the Host header instead of the bizarre and complicated heuristic it was using.

The squid change should have been simply a matter of replacing `accel` with `vhost`, but it wasn't, because we were using  `url_regex` for the routing rules, and apparently `vhost` mode changes the host in the URL that's presented for matching. The solution to this was another change I've long wanted to make, which is to distinguish inbound requests from outbound requests by the port they came in on, rather than by hostname. This will also make testing a lot easier in its own right.

I'm also changing the handler for squid config changes from `reconfigure squid` to `restart squid`, because I found that reconfigure wasn't sufficient for the vhost change to take effect.

I have tested this on the Mali server and it resolves all the problems I was aware of, including python maproom redirects and Ingrid KML downloads.