### PR TITLE
Shut down open proxy

### DIFF
--- a/example/playbook.yaml
+++ b/example/playbook.yaml
@@ -35,6 +35,14 @@
       # username: uid
       testuser: 1001
 
+    # Host names and/or IP addresses that will be used to access the
+    # server. If your server has multiple IP addresses (e.g. private
+    # and public), list them all here. Must include {{test_host}} or
+    # else the ansible tests will fail.
+    dl_hosts:
+      - "{{test_host}}"
+      - localhost
+
   # Invokes the iridl ansible role. Don't modify this.
   roles:
     - iridl.iridl.iridl

--- a/roles/iridl/defaults/main.yaml
+++ b/roles/iridl/defaults/main.yaml
@@ -22,10 +22,13 @@ docker_max_concurrent_downloads: 3
 # when updating the configuration of an existing installation.
 run_update_script: no
 
-# The hostname and optional port that users will connect to. This might not be
-# the same as the port squid is listening on, if there's another proxy in
-# between.
-dl_hostport: "{{ansible_host}}"
+# The host and port that ansible tests will attempt to connect
+# to. Usually the host is the same as the one ansible connects to, so
+# you can probably leave this set to the default. If there is port
+# forwarding involved, as when testing in Vagrant, you will need to
+# override the default port.
+test_host: "{{ansible_host}}"
+test_port: "80"
 
 # The mount point of a large disk volume (typically multiple TB). The
 # base of defaults for other directories defined below.

--- a/roles/iridl/tasks/main.yaml
+++ b/roles/iridl/tasks/main.yaml
@@ -476,7 +476,7 @@
 
 - name: service tests
   uri:
-    url: http://{{dl_hostport}}{{item}}
+    url: http://{{test_host}}:{{test_port}}{{item}}
     headers:
       Cache-Control: no-cache # force squid to talk to the backend
   retries: 5
@@ -503,7 +503,7 @@
 
 - name: verify that ingrid can talk to db
   uri:
-    url: http://{{dl_hostport}}/IRIDB/(select%20count(*)%20from%20nosuchtable)/openquery/
+    url: http://{{test_host}}:{{test_port}}/IRIDB/(select%20count(*)%20from%20nosuchtable)/openquery/
     headers:
       Cache-Control: no-cache
     return_content: yes
@@ -520,7 +520,7 @@
 
 - name: verify that python_maproom is running
   uri:
-    url: http://{{dl_hostport}}/python_maproom/health
+    url: http://{{test_host}}:{{test_port}}/python_maproom/health
     headers:
       Cache-Control: no-cache
     return_content: yes

--- a/roles/iridl/templates/squid.conf
+++ b/roles/iridl/templates/squid.conf
@@ -19,9 +19,9 @@ acl Safe_ports port 777		# multiling http
 acl Safe_ports port 888		# ganglia
 acl CONNECT method CONNECT
 
-acl inbound myport 80
+acl inbound dstdomain {{ dl_hosts | join(' ') }}
+acl outbound myport 3128 # only valid if 3128 isn't exposed externally
 
-acl ingrid_url urlpath_regex ^/
 acl maproom_url urlpath_regex ^/(maproom|uicore|pure|jsonld|localconfig|docfind|dochelp|index.html|\?|$)
 {% if python_maproom_repo is defined %}
 acl python_maproom_url urlpath_regex ^/python_maproom
@@ -32,7 +32,8 @@ http_access deny !Safe_ports
 http_access deny CONNECT !SSL_ports
 http_access allow localhost
 http_access allow localnet
-http_access allow inbound ingrid_url
+http_access allow inbound
+http_access allow outbound
 http_access deny all
 http_reply_access allow all
 
@@ -59,7 +60,7 @@ cache_peer_access ingrid deny maproom_url
 cache_peer_access ingrid deny python_maproom_url
 {% endif %}
 cache_peer_access ingrid deny fbfmaproom_url
-cache_peer_access ingrid allow inbound ingrid_url
+cache_peer_access ingrid allow inbound
 cache_peer_access ingrid deny all
 
 
@@ -114,8 +115,6 @@ max_filedesc 4096
 
 shutdown_lifetime {{squid_shutdown_lifetime}} seconds
 
-# Report the actual hostname rather than the container name in Via and
-# X-Cache headers. Must match the name used by back squid for
-# squid-internal URLs, e.g. /squid-internal-periodic/store_digest, to
-# work.
-visible_hostname {{dl_hostport}}
+# Report something meaningful instead of the container's internal
+# hostname name in Via and X-Cache headers.
+visible_hostname dlsquid

--- a/roles/iridl/templates/squid.conf
+++ b/roles/iridl/templates/squid.conf
@@ -1,8 +1,5 @@
 #debug_options 28,5
 acl all src all
-acl localhost src 127.0.0.1/32
-acl to_localhost dst 127.0.0.0/8
-acl localnet src {{docker_virtual_network}}
 
 acl SSL_ports port 443 563 1443
 acl Safe_ports port 80-89 1004		# http
@@ -30,8 +27,6 @@ acl fbfmaproom_url urlpath_regex ^/fbfmaproom
 
 http_access deny !Safe_ports
 http_access deny CONNECT !SSL_ports
-http_access allow localhost
-http_access allow localnet
 http_access allow inbound
 http_access allow outbound
 http_access deny all

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "dlserver1", primary: true do |x|
     x.vm.network "forwarded_port", guest: 22, host: 2230 # must match ansible_port in inventory
-    x.vm.network "forwarded_port", guest: 80, host: 8090 # must match dl_hostport in inventory
+    x.vm.network "forwarded_port", guest: 80, host: 8090 # must match test_port in inventory
     x.vm.provider :virtualbox do |vb|
       vb.memory = 3 * 1024
     end

--- a/tests/inventory.cfg
+++ b/tests/inventory.cfg
@@ -18,4 +18,4 @@ docker_registry_mirror = http://10.0.2.2:5000
 # The hostname and port that users will visit. Defaults to
 # ansible_host, but when testing in Vagrant, VirtualBox
 # proxies the connection.
-dl_hostport = "{{ansible_host}}:8090" # port must match setting in Vagrantfile
+test_port = 8090  # must match setting in Vagrantfile

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -151,7 +151,7 @@ _playbook() {
 }
 
 cd $(dirname $0) || fail
-mode=host
+mode=guest
 while (( $# )); do
     echo $1
     case $1 in


### PR DESCRIPTION
Going back to identifying inbound requests by destination, which is a bit of a pain (have to list the addresses of all interfaces an inbound request might come through, including any proxies), but I can't find any other way to do it.

I've tested this in Vagrant and on the Mali server.