### PR TITLE
Open postgres to processes running on the docker host

### DIFF
--- a/roles/iridl/templates/docker-compose.yaml
+++ b/roles/iridl/templates/docker-compose.yaml
@@ -53,6 +53,8 @@ services:
 
   postgres:
     image: iridl/ingriddb:{{ingriddb_version}}
+    ports:
+      - 127.0.0.1:5432:5432
     expose:
       - 5432
     command: "run"


### PR DESCRIPTION
This is for partner sites. The postgres container port was previously exposed only within the docker virtual network, which meant that python maproom developers working on the server in their home directory couldn't connect to it. Now I'm forwarding port 5432 on the host to the container to support that development process. Port 5432 should still be closed to the internet, though that's a bit hard to verify in vagrant because vagrant doesn't expose ports like that anyway.

@remicousin I claimed to have made this change on the Guyana server already, but I just noticed that this branch hasn't been merged, so I guess I didn't.