### PR TITLE
Forecast automation

### DIFF
--- a/example/playbook.yaml
+++ b/example/playbook.yaml
@@ -53,7 +53,7 @@
       conda_env_name: test
       conda_env_file: test-conda-linux-64.lock
 
-    # Installs pycpt in a conda environment. Comment this out if you
-    # won't be running pycpt on the server.
-    - role: iridl.iridl.pycpt
-      pycpt_version: 2.7.2
+    # Installs pycpt in a conda environment. Not needed if pycpt is
+    # configured in python_maprooms.
+    # - role: iridl.iridl.pycpt
+    #   pycpt_version: 2.7.2

--- a/roles/iridl/meta/main.yaml
+++ b/roles/iridl/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: miniconda

--- a/roles/iridl/tasks/main.yaml
+++ b/roles/iridl/tasks/main.yaml
@@ -310,19 +310,6 @@
     dest: /etc/sudoers.d/datag_update
     mode: 0400
 
-- name: run update script
-  command: "bash -x {{update_script}} --build-classic"
-  when: run_update_script | bool
-  register: update_script
-
-- block:
-  - debug:
-      msg: "{{update_script.stderr_lines}}"
-
-  - debug:
-      msg: "{{update_script.stdout_lines}}"
-  when: update_script is not skipped
-
 - name: sql import dir
   file:
     path: "{{sql_dir}}"
@@ -403,6 +390,19 @@
   template:
     src: docker-compose.yaml
     dest: "{{compose_project_dir}}/docker-compose.yaml"
+
+- name: run update script
+  command: "bash -x {{update_script}} --build-classic"
+  when: run_update_script | bool
+  register: update_script
+
+- block:
+  - debug:
+      msg: "{{update_script.stderr_lines}}"
+
+  - debug:
+      msg: "{{update_script.stdout_lines}}"
+  when: update_script is not skipped
 
 - name: update docker-compose state for services pulled from registries
   docker_compose:

--- a/roles/iridl/tasks/main.yaml
+++ b/roles/iridl/tasks/main.yaml
@@ -299,12 +299,13 @@
 - name: update script
   template:
     dest: "{{update_script}}"
-    mode: 0744
+    mode: 0755
     src: "update_datalib"
 
 - name: datag sudoers config
   copy:
     content: |
+      Defaults secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
       %datag ALL=(root) NOPASSWD: {{update_script}}
     dest: /etc/sudoers.d/datag_update
     mode: 0400

--- a/roles/iridl/tasks/main.yaml
+++ b/roles/iridl/tasks/main.yaml
@@ -440,6 +440,12 @@
     msg: "{{docker_compose_result.actions}}"
   when: python_maproom_repo is defined
 
+- name: generate-forecasts script
+  template:
+    src: generate-forecasts
+    dest: /usr/local/bin/generate-forecasts
+    mode: ugo+x
+
 - name: clean up files from old locations
   file:
     path: "{{item}}"

--- a/roles/iridl/tasks/main.yaml
+++ b/roles/iridl/tasks/main.yaml
@@ -440,11 +440,22 @@
     msg: "{{docker_compose_result.actions}}"
   when: python_maproom_repo is defined
 
+
+#
+# Tools for managing PyCPT forecasts
+#
 - name: generate-forecasts script
   template:
     src: generate-forecasts
     dest: /usr/local/bin/generate-forecasts
     mode: ugo+x
+
+- name: upload-forecasts script
+  template:
+    src: upload-forecasts
+    dest: /usr/local/bin/upload-forecasts
+    mode: ugo+x
+
 
 - name: clean up files from old locations
   file:

--- a/roles/iridl/templates/generate-forecasts
+++ b/roles/iridl/templates/generate-forecasts
@@ -22,4 +22,4 @@ source {{miniconda_path}}/etc/profile.d/conda.sh
 conda activate pycpt-$pycpt_version
 
 # run pycpt
-generate-forecasts "$config_dir/config.py"
+generate-forecasts-from-config "$config_dir/config.py"

--- a/roles/iridl/templates/generate-forecasts
+++ b/roles/iridl/templates/generate-forecasts
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+fcst_name=$1
+
+configs_dir={{python_maproom_src_dir}}/pycpt-forecasts
+
+config_dir="$configs_dir/$fcst_name"
+if [ $# -ne 1 ] || ! [ -d "$config_dir" ]; then
+    echo "Usage: $0 <forecast_name>"
+    echo "forecast_name must match one of the subdirectories of $configs_dir :"
+    ls "$configs_dir"
+    exit 1
+fi
+
+# read pycpt version from config file
+pycpt_version=$(cat "$config_dir/pycpt-version")
+
+# activate conda environment for the specified pycpt version
+source {{miniconda_path}}/etc/profile.d/conda.sh
+conda activate pycpt-$pycpt_version
+
+# run pycpt
+generate-forecasts "$config_dir/config.py"

--- a/roles/iridl/templates/update_datalib
+++ b/roles/iridl/templates/update_datalib
@@ -84,6 +84,19 @@ init_git {{python_maproom_repo.url}} {{python_maproom_src_dir}} \
          {{python_maproom_repo.version}} {{git_ssh_prefix}}{{python_maproom_repo.name}}
 
 docker build -t {{python_maproom_repo.name}}:{{python_maproom_repo.version}} . || fail $? "python maproom build failed"
+
+shopt -s nullglob
+for f in pycpt-forecasts/*/pycpt-version; do
+    pycpt_version=$(cat "$f")
+    if ! [ -x {{miniconda_path}}/envs/pycpt-$pycpt_version/bin/python ]; then
+        lockfile=/tmp/conda-linux-64.lock.$$
+        curl -L -o $lockfile https://github.com/iri-pycpt/notebooks/releases/download/v$pycpt_version/conda-linux-64.lock
+        source {{miniconda_path}}/etc/profile.d/conda.sh
+        conda create -n pycpt-$pycpt_version --file $lockfile
+        rm $lockfile
+    fi
+done
+shopt -u nullglob
 {% endif %}
 
 ### maproom

--- a/roles/iridl/templates/update_datalib
+++ b/roles/iridl/templates/update_datalib
@@ -90,9 +90,9 @@ for f in pycpt-forecasts/*/pycpt-version; do
     pycpt_version=$(cat "$f")
     if ! [ -x {{miniconda_path}}/envs/pycpt-$pycpt_version/bin/python ]; then
         lockfile=/tmp/conda-linux-64.lock.$$
-        curl -L -o $lockfile https://github.com/iri-pycpt/notebooks/releases/download/v$pycpt_version/conda-linux-64.lock
-        source {{miniconda_path}}/etc/profile.d/conda.sh
-        conda create -n pycpt-$pycpt_version --file $lockfile
+        curl -L -o $lockfile https://github.com/iri-pycpt/notebooks/releases/download/v$pycpt_version/conda-linux-64.lock || fail
+        source {{miniconda_path}}/etc/profile.d/conda.sh || fail
+        conda create -n pycpt-$pycpt_version --file $lockfile || fail
         rm $lockfile
     fi
 done
@@ -116,12 +116,12 @@ fi
 if [[ -d {{compose_project_dir}} ]]; then  # doesn't exist yet on first run
     cd {{compose_project_dir}} || fail $? "failed to cd"
 
-    docker-compose up -d
+    docker-compose up -d || fail
 
-    docker-compose restart ingrid
-    docker-compose restart maproom
+    docker-compose restart ingrid || fail
+    docker-compose restart maproom || fail
     # in case one of the services was previously down, tell squid to check again.
-    docker-compose exec -T squid squid -k reconfigure
+    docker-compose exec -T squid squid -k reconfigure || fail
 fi
 
 exit 0

--- a/roles/iridl/templates/upload-forecasts
+++ b/roles/iridl/templates/upload-forecasts
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+fcst_name=$1
+
+configs_dir={{python_maproom_src_dir}}/pycpt-forecasts
+
+config_dir="$configs_dir/$fcst_name"
+if [ $# -ne 1 ] || ! [ -d "$config_dir" ]; then
+    echo "Usage: $0 <forecast_name>"
+    echo "forecast_name must match one of the subdirectories of $configs_dir :"
+    ls "$configs_dir"
+    exit 1
+fi
+
+# read pycpt version from config file
+pycpt_version=$(cat "$config_dir/pycpt-version")
+
+# activate conda environment for the specified pycpt version
+source {{miniconda_path}}/etc/profile.d/conda.sh
+conda activate pycpt-$pycpt_version
+
+# run pycpt
+upload-forecasts "$config_dir/config.py"

--- a/roles/iridl/templates/upload-forecasts
+++ b/roles/iridl/templates/upload-forecasts
@@ -22,4 +22,4 @@ source {{miniconda_path}}/etc/profile.d/conda.sh
 conda activate pycpt-$pycpt_version
 
 # run pycpt
-upload-forecasts "$config_dir/config.py"
+upload-forecasts-from-config "$config_dir/config.py"


### PR DESCRIPTION
On partner DLs, the `python_maproom` repo can now contain an optional `pycpt-forecasts` directory. If that directory exists, `update_datalib` will install pycpt in a conda environment and make it available via a script called `generate-forecasts`. Each forecast configuration indicates which version of pycpt should be used, and `generate-forecasts` runs the right version of pycpt for each configuration.

I also changed the sudo configuration so that we can now run `sudo update_datalib` instead of `sudo /usr/local/bin/update_datalib`.

Lesotho will be the first place we use this. It is urgent that we get this installed there this week so we can bill for the deliverable before the end of the month.