### PR TITLE
Disable PackageKit

### DIFF
--- a/roles/iridl/tasks/main.yaml
+++ b/roles/iridl/tasks/main.yaml
@@ -1,6 +1,23 @@
 #
 # General system settings
 #
+
+# Disable PackageKit so it doesn't grab the yum lock and prevent this
+# playbook from running. PackageKit is not included in the minimal
+# server image, but some partners do a desktop installation.
+
+- name: stop PackageKit if running
+  systemd:
+    name: packagekit
+    state: stopped
+  failed_when: false
+
+- name: mask PackageKit
+  systemd:
+    name: packagekit
+    masked: true
+
+
 - name: enable EPEL yum repo
   yum:
     name: epel-release

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure("2") do |config|
     x.vm.network "forwarded_port", guest: 22, host: 2230 # must match ansible_port in inventory
     x.vm.network "forwarded_port", guest: 80, host: 8090 # must match test_port in inventory
     x.vm.provider :virtualbox do |vb|
-      vb.memory = 3 * 1024
+      vb.memory = 4 * 1024
     end
     x.vm.synced_folder "..", "/vagrant"
     x.vm.provision "file", source: "CentOS-Vault.repo", destination: "/tmp/"


### PR DESCRIPTION
On a recent call with Niger, the playbook failed because PackageKit was holding the yum lock. This disables it.

Minimal server installs don't have PackageKit, but desktop installs do. I've tested this both with and without PackageKit installed.

Conda ran out of memory when I first tried to test, so I'm increasing the VM memory. Eventually we'll switch the application environments to pixi, which should reduce memory usage (and image build time too).