### PR TITLE
Update maproom-dev image

### DIFF
--- a/roles/iridl/defaults/main.yaml
+++ b/roles/iridl/defaults/main.yaml
@@ -67,5 +67,5 @@ mail_relay: null
 ingrid_version: d250324
 ingriddb_version: d13b453
 maproom_base_version: 3450dbf
-maproom_dev_version: 3450dbf
+maproom_dev_version: d22d3bd
 dlsquid_version: de6ed54


### PR DESCRIPTION
I released a new version of maproom-dev that makes the classic maproom build use local copies of DTDs instead of fetching them from the iridl. I never realized they were being fetched from iridl until builds started failing because Cloudflare rejected the requests.