### PR TITLE
Centos9 and 10

### DIFF
--- a/roles/iridl/defaults/main.yaml
+++ b/roles/iridl/defaults/main.yaml
@@ -68,4 +68,4 @@ maproom_base_version: 3450dbf
 maproom_dev_version: d22d3bd
 dlsquid_version: de6ed54
 
-docker-ce-version: "docker-ce-3:28.3.2-1.el{{ansible_distribution_major_version}}"
+docker_ce_version: "docker-ce-3:28.3.2-1.el{{ansible_distribution_major_version}}"

--- a/roles/iridl/defaults/main.yaml
+++ b/roles/iridl/defaults/main.yaml
@@ -58,8 +58,6 @@ admin_emails: []
 # mail_relay: "[mail.example.com]:25"
 mail_relay: null
 
-
-
 # Container version numbers for the various Data Library software
 # packages. Do not use "latest", or you might find your software
 # being updated when you don't expect it, potentially to a
@@ -69,3 +67,5 @@ ingriddb_version: d13b453
 maproom_base_version: 3450dbf
 maproom_dev_version: d22d3bd
 dlsquid_version: de6ed54
+
+docker-ce-version: "docker-ce-3:28.3.2-1.el{{ansible_distribution_major_version}}"

--- a/roles/iridl/tasks/main.yaml
+++ b/roles/iridl/tasks/main.yaml
@@ -186,13 +186,11 @@
     state: absent
 
 - name: install docker-ce
-  # latest stable versions as of 3/7/25
   # installing docker-ce installs the appropriate dependencies that were previously defined here:
   # - docker-ce-cli, containerd-io, docker-buildx-plugin, docker-compose-plugin
   package:
-    name:
-      # let docker-ce determine the corresponding packages it requires
-      - docker-ce-3:28.0.1-1.el9
+    name: "{{docker-ce-version}}"
+    state: present
 
 - name: docker config file
   template:

--- a/roles/iridl/tasks/main.yaml
+++ b/roles/iridl/tasks/main.yaml
@@ -189,7 +189,7 @@
   # installing docker-ce installs the appropriate dependencies that were previously defined here:
   # - docker-ce-cli, containerd-io, docker-buildx-plugin, docker-compose-plugin
   package:
-    name: "{{docker-ce-version}}"
+    name: "{{docker_ce_version}}"
     state: present
 
 - name: docker config file

--- a/roles/iridl/templates/postfix/main.cf
+++ b/roles/iridl/templates/postfix/main.cf
@@ -12,8 +12,8 @@ unknown_local_recipient_reject_code = 550
 {% if mail_relay is not none %}
 relayhost = {{ mail_relay }}
 {% endif %}
-alias_maps = hash:/etc/aliases
-alias_database = hash:/etc/aliases
+alias_maps = lmdb:/etc/aliases
+alias_database = lmdb:/etc/aliases
 debug_peer_level = 2
 debugger_command =
 	 PATH=/bin:/usr/bin:/usr/local/bin:/usr/X11R6/bin


### PR DESCRIPTION
Allows installation of IRIDL via ansible to CentOS Stream 9 or 10.  Minor changes as postfix no longer supports hash maps and upgrade to the current version of docker-ce, while making the docker-ce version a variable.

Tested as new installs on CentOS Stream 9 and 10 servers: dlansible9.iri.columbia.edu, dlansible10.iri.columbia.edu

Will updated the documentation to avoid referencing the specific CentOS Stream version