### PR TITLE
Simplify _is_vagrant

### DIFF
--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -10,7 +10,6 @@ dnf install -y git python3.12
 python3.12 -m venv /opt/datalib_venv3.12
 /opt/datalib_venv3.12/bin/pip install --upgrade pip
 /opt/datalib_venv3.12/bin/pip install ansible==11.3.0 requests==2.32.3
-hostnamectl hostname vagrant-iridl-ansible
 EOF
 
 Vagrant.configure("2") do |config|

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -110,9 +110,6 @@ _up() {
     # vagrant-reload plugin would be a cleaner way to handle this, but
     # the version of vagrant I'm getting from ubuntu 18.04 is too old
     # to support that.
-    if _is_vagrant; then
-      return
-    fi
     vagrant up || return 1
     echo waiting for VM
     i=10

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -37,13 +37,6 @@
 
 builddir="${HOME}/dlconfig"
 
-_is_vagrant() {
-    if [[ "${HOSTNAME}" == "vagrant-iridl-ansible" ]]; then
-        return 0
-    fi
-    return 1
-}
-
 fail() {
     echo $*
     exit 1
@@ -139,19 +132,24 @@ _playbook() {
 
 cd $(dirname $0) || fail
 
+where=host
 while (( $# )); do
     case $1 in
+        --guest)
+            where=guest
+            shift
+            ;;
         destroy)
             $1 || fail
             shift
             ;;
         full | incremental | idempotency | ansible_test)
-            if _is_vagrant; then
+            if [ "$where" == guest ]; then
                 _install || fail
                 $1 || fail
             else
                 _up || fail
-                vagrant ssh -- exec bash -l -c "'/vagrant/tests/$(basename $0) $1'" || fail
+                vagrant ssh -- exec bash -l -c "'/vagrant/tests/$(basename $0) --guest $1'" || fail
             fi
             shift
             ;;

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -92,11 +92,6 @@ idempotency() {
 }
 
 _install() {
-    if ! _is_vagrant; then
-      vagrant rsync
-      return
-    fi
-
     if [[ ! -d "${builddir}" ]]; then
         mkdir "${builddir}" || return 1
         source /opt/datalib_venv3.12/bin/activate


### PR DESCRIPTION
I got myself into a weird situation that turned out to be caused by creating a vm from the centos7 branch and then running run_tests on master. That was my error, but the unnecessary complexity of this _is_vagrant check made it harder than it needed to be to figure out what was wrong.